### PR TITLE
add version flag based on VERSION file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 c.out
 build
 release
+version.go

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ RELEASE_ARTIFACTS := $(COMPRESSED_BUILDS:build/%=release/%)
 
 test: $(PKG)
 
-$(PKG):
+$(PKG): version.go
 	go get github.com/golang/lint/golint
 	$(GOPATH)/bin/golint $(GOPATH)/src/$@*/**.go
 	go get -d -t $@
@@ -20,6 +20,12 @@ $(PKG):
 ifeq ($(HTMLCOV),1)
 	go tool cover -html=$(GOPATH)/src/$@/c.out
 endif
+
+build/*: version.go
+version.go: VERSION
+	echo 'package main' > version.go
+	echo '' >> version.go # Write a go file that lints :)
+	echo 'const Version = "$(VERSION)"' >> version.go
 
 build/$(EXECUTABLE)-v$(VERSION)-darwin-amd64:
 	GOARCH=amd64 GOOS=darwin go build -o "$@/$(EXECUTABLE)"

--- a/main.go
+++ b/main.go
@@ -93,7 +93,13 @@ func main() {
 	interval := flags.Int("interval", 1, "how often, in seconds, to poll mongo for operations")
 	querystr := flags.String("query", `{"op": "query", "secs_running": {"$gt": 60}}`, "query sent to db.currentOp()")
 	debug := flags.Bool("debug", true, "in debug mode, operations that match the query are logged instead of killed")
+	version := flags.Bool("version", false, "print the version and exit")
 	flags.Parse(os.Args[1:])
+
+	if *version {
+		fmt.Println(Version)
+		os.Exit(0)
+	}
 
 	var query bson.M
 	if err := json.Unmarshal([]byte(*querystr), &query); err != nil {


### PR DESCRIPTION
There's a couple tools that embed static assets in go binaries: https://github.com/aleksa/gopacker, https://github.com/jteeuwen/go-bindata

All of them seemed a bit heavyweight for what we want to do here (basically just keep the `version` command line flag up to do date with the `VERSION` file, without requiring manual editing) but I could be convinced to try go-bindata or something else. gopacker is a perl script.
