### PR TITLE
[INFRA-3218] CircleCI 1.0 -> 2.0 migration cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,5 +19,4 @@ jobs:
     - run: make version.go
     - run: make install_deps
     - run: make test
-    - run: $HOME/ci-scripts/circleci/report-card $RC_DOCKER_USER $RC_DOCKER_PASS "$RC_DOCKER_EMAIL" $RC_GITHUB_TOKEN
-    
+    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then make release && $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN release; fi;


### PR DESCRIPTION
JIRA: [INFRA-3218](https://clever.atlassian.net/browse/INFRA-3218)

Improve on the initial CircleCI autotranslation:
- add back github-release (accidentally removed) 
- rm report-card  (deprecated)



prevoius: https://github.com/Clever/whackanop/pull/23/files